### PR TITLE
fix: update documentation to use decisions/ instead of .decisions/

### DIFF
--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -93,7 +93,7 @@ ADRs and issues serve different purposes:
 | Mutability | Append-only events | Evolve during draft, stable after |
 
 **Linking pattern:**
-- Issues reference ADRs: "Implements ADR-002" or "See `.decisions/002-...` for design"
+- Issues reference ADRs: "Implements ADR-002" or "See `decisions/002-...` for design"
 - ADRs optionally list related issues
 
 ## Creating an ADR

--- a/.issues/events-sd.jsonl
+++ b/.issues/events-sd.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-07T16:13:55Z","type":"created","id":"sd-001","title":"Update README/code to refer to decisions rather than .decisions","issue_type":"task","priority":2}
+{"ts":"2026-01-07T16:16:15Z","type":"closed","id":"sd-001","reason":"Fixed - updated README.md and .claude/skills/adr/SKILL.md to use decisions/ instead of .decisions/"}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To update: `git pull` (in the skill-issues directory)
 
 You can also install skills individually: `issues init`, `sessions init`, `adr init`
 
-Data directories (`.issues/`, `.memory/`, `.decisions/`) are created automatically on first use.
+Data directories (`.issues/`, `.sessions/`) are created automatically on first use.
 
 ## Usage
 
@@ -118,10 +118,10 @@ Created session s028 capturing learnings and issues worked.
 **When facing a design choice:**
 > "We need to decide between SQLite and JSONL for storage - let's write up an ADR"
 
-Claude creates a decision record in `.decisions/` capturing context, options, and rationale:
+Claude creates a decision record in `decisions/` capturing context, options, and rationale:
 
 ```
-.decisions/
+decisions/
 ├── 001-sessions-vs-issues.md
 ├── 002-github-issues-compatibility.md
 └── 003-design-doc-process.md


### PR DESCRIPTION
## Summary
- Updates README.md and .claude/skills/adr/SKILL.md to reference `decisions/` instead of `.decisions/`
- Also fixes `.memory/` → `.sessions/` reference in README.md

## Test plan
- [x] Verify all `.decisions/` references in documentation are updated
- [x] Confirm the changes match the actual folder structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)